### PR TITLE
Add render all imgs method, update render card

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -48,6 +48,7 @@ const controlAddFiles = async function (fileList) {
   }
 
   mapView.clearRouteLine();
+  panelView.input.value = '';
 };
   
 const controlPreviewClick = function (i) {

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -6,6 +6,7 @@ import { DEFAULT_COORDS } from './config.js';
 if (module.hot) {
   module.hot.accept();
 }
+
 const controlAddFiles = async function (fileList) {
   panelView._submitBtn.disabled = false;
   Array.from(fileList).forEach(async (file, i) => {
@@ -17,6 +18,8 @@ const controlAddFiles = async function (fileList) {
       try {
         const exifData = await model.getExifData(file);
         const { latitude, longitude } = exifData;
+        model.state.uploadedImages[i].latitude = latitude;
+        model.state.uploadedImages[i].longitude = longitude;
         model.state.imageCoords.push({
           photoIndex: i,
           lat: latitude,
@@ -25,7 +28,7 @@ const controlAddFiles = async function (fileList) {
 
         // Create a photo marker
         mapView.renderPhotoMarker(latitude, longitude, file, i);
-        panelView.renderPreviewCard(file, exifData, i);
+        panelView.renderPreviewCard(model.state.uploadedImages[i]);
         mapView.map.flyToBounds(model.state.imageCoords);
       } catch (e) {
         console.error(e);
@@ -170,6 +173,7 @@ const controlClear = function () {
 const init = function () {
   console.log('Snappy trails is up and running. Reticulating splines');
 
+  model.state.imageCoords.length > 0 && panelView.renderAllImgs(model.state);
   mapView.render();
   panelView.addHandlerUserLocation(controlUserLocation);
   panelView.addHandlerFileInput(controlAddFiles);

--- a/src/js/views/panelView.js
+++ b/src/js/views/panelView.js
@@ -15,7 +15,6 @@ class PanelView {
       const fileList = this.files;
       if (!fileList.length) return;
       handler(fileList);
-      this.value = null;
     });
   }
   addHandlerRemoveImage(handler) {
@@ -81,15 +80,13 @@ class PanelView {
     this._userLocationInput.addEventListener('change', (e) => handler(e));
   }
   // Function to print image, info and coords to preview area
-  renderPreviewCard(img) {
-    const {
-      file,
-      file: { exifdata },
-      latitude,
-      longitude,
-      photoIndex,
-    } = img;
-
+  renderPreviewCard({
+    file,
+    file: { exifdata },
+    latitude,
+    longitude,
+    photoIndex,
+  }) {
     // Create preview card element
     const previewCard = document.createElement('div');
     previewCard.classList.add('preview__card');

--- a/src/js/views/panelView.js
+++ b/src/js/views/panelView.js
@@ -1,7 +1,7 @@
 import { miliToTime, round, toMiles } from '../helpers';
 class PanelView {
   _parentElement = document.querySelector('#upload-form');
-  _input = document.querySelector('#fileInput');
+  input = document.querySelector('#fileInput');
   _submitBtn = document.querySelector('#submit-route-btn');
   _clearBtn = document.querySelector('#clear-btn');
   _userLocationInput = document.querySelector('#user-location');
@@ -11,7 +11,7 @@ class PanelView {
   locationPreviewCard;
 
   addHandlerFileInput(handler) {
-    this._input.addEventListener('change', async function (e) {
+    this.input.addEventListener('change', async function (e) {
       const fileList = this.files;
       if (!fileList.length) return;
       handler(fileList);

--- a/src/js/views/panelView.js
+++ b/src/js/views/panelView.js
@@ -19,13 +19,17 @@ class PanelView {
     });
   }
   addHandlerRemoveImage(handler) {
-    this.preview.addEventListener('click', function (e) {
-      const removeBtn = e.target.closest('.preview__card--remove-btn');
-      if (!removeBtn) return;
-      e.stopImmediatePropagation();
-      const imgIndex = e.target.closest('.preview__card').dataset.photoIndex;
-      handler(imgIndex);
-    }, true);
+    this.preview.addEventListener(
+      'click',
+      function (e) {
+        const removeBtn = e.target.closest('.preview__card--remove-btn');
+        if (!removeBtn) return;
+        e.stopImmediatePropagation();
+        const imgIndex = e.target.closest('.preview__card').dataset.photoIndex;
+        handler(imgIndex);
+      },
+      true
+    );
   }
   addHandlerPreviewClick(handler) {
     this.preview.addEventListener('click', function (e) {
@@ -35,15 +39,15 @@ class PanelView {
       handler(imgIndex);
     });
   }
-  addHandlerLocationPreviewClick(handler){
-    this.preview.addEventListener('click', function(e) {
+  addHandlerLocationPreviewClick(handler) {
+    this.preview.addEventListener('click', function (e) {
       e.preventDefault();
       const locationPreviewCard = e.target.closest('.location__card');
-      if(!locationPreviewCard) return;
+      if (!locationPreviewCard) return;
       handler();
-    })
+    });
   }
-  addHandlerRemoveCurrentLocation(handler){
+  addHandlerRemoveCurrentLocation(handler) {
     this.preview.addEventListener('click', function (e) {
       const removeBtn = e.target.closest('.location__card--remove-btn');
       if (!removeBtn) return;
@@ -66,7 +70,7 @@ class PanelView {
       handler();
       // Remove all image previews
       this.preview.replaceChildren();
-      this.routePreviewCard.remove();
+      !!this.routePreviewCard && this.routePreviewCard.remove();
 
       // reset to default coords/world view
       this.form.reset();
@@ -77,11 +81,19 @@ class PanelView {
     this._userLocationInput.addEventListener('change', (e) => handler(e));
   }
   // Function to print image, info and coords to preview area
-  renderPreviewCard(file, exifData, i) {
+  renderPreviewCard(img) {
+    const {
+      file,
+      file: { exifdata },
+      latitude,
+      longitude,
+      photoIndex,
+    } = img;
+
     // Create preview card element
     const previewCard = document.createElement('div');
     previewCard.classList.add('preview__card');
-    previewCard.dataset.photoIndex = i;
+    previewCard.dataset.photoIndex = photoIndex;
     const previewCardHeader = document.createElement('div');
     previewCardHeader.classList.add('preview__card--header');
     const previewCardText = document.createElement('div');
@@ -100,21 +112,20 @@ class PanelView {
 
     // Convert image date from exif data format to javascript format
     const [year, month, day, hours, minutes, seconds] =
-      exifData.DateTime.split(/[: ]/);
+      exifdata.DateTime.split(/[: ]/);
     const dateObject = new Date(year, month - 1, day, hours, minutes, seconds);
 
     previewCardText.innerHTML = `
-      <h4>${file.name}</h4>
       <dl>
         <dt>Date:</dt><dd>${dateObject.toLocaleDateString()}</dd>
         <dt>Time:</dt><dd>${dateObject.toLocaleTimeString([], {
           hour: '2-digit',
           minute: '2-digit',
         })}</dd>
-        <dt>lat, lng: </dt><dd>${exifData.latitude.toFixed(
-          2
-        )}, ${exifData.longitude.toFixed(2)}</dd>
-        <dt>Camera:</dd><dd> ${exifData.Make} ${exifData.Model}</dd>
+        <dt>lat, lng: </dt><dd>${latitude.toFixed(2)}, ${longitude.toFixed(
+      2
+    )}</dd>
+        <dt>Camera:</dd><dd> ${exifdata.Make} ${exifdata.Model}</dd>
       </dl>
     `;
     // Append card items
@@ -173,6 +184,10 @@ class PanelView {
     previewCardRemoveBtn.setAttribute('title', 'Remove current location');
     previewCardRemoveBtn.classList.add('location__card--remove-btn');
     this.locationPreviewCard.appendChild(previewCardRemoveBtn);
+  }
+  // Render all cards from state
+  renderAllImgs(state) {
+    state.uploadedImages.map((img) => this.renderPreviewCard(img));
   }
 }
 


### PR DESCRIPTION
In this PR, I've modified the `uploadedImages` state array to include a reference to the image latitude and longitude. This likely paves the way to remove the `imageCoords` state array, as this information is now duplicated. Worth investigating if continuing to hold the `File` in the state is performance-heavy; I realized that the lat/lon and the photo index was duplicated, so this PR tries to move towards de-duping that info.

This also sets up the render method to render all images from the state at once.