### PR TITLE
Route panel

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -49,8 +49,12 @@ const controlPreviewClick = function (i) {
 };
 
 const controlRouteCardClick = function () {
-  panelView.renderRoutePanel(model.state.routeData);
+  panelView.renderRoutePanel(model.state.routeData, model.state.transportMode);
 };
+const controlRouteBackClick = function () {
+  console.log('clicked')
+  // panelView.renderForm();
+}
 
 const controlRemoveImage = function (i) {
   mapView.photoMarkers.eachLayer((layer) => {
@@ -152,7 +156,8 @@ const controlRemoveLocationPreview = function () {
 };
 
 const controlSubmit = async function (transportMode) {
-  const routeData = await model.getRoute(transportMode);
+  model.state.transportMode = transportMode;
+  const routeData = await model.getRoute(model.state.transportMode);
   model.state.routeData = routeData;
   mapView.map.flyToBounds(model.state.imageCoords);
   mapView.renderRouteLine(model.state.routeData);
@@ -169,6 +174,14 @@ const controlClear = function () {
   mapView.routeLine.remove();
   // Reset map view
   mapView.map.flyTo([DEFAULT_COORDS[1], DEFAULT_COORDS[0]], 10);
+  // Remove all image previews
+  panelView.preview.replaceChildren();
+  panelView.routePreviewCard.remove();
+  panelView.routePanel.remove();
+
+  // reset to default coords/world view
+  panelView.form.reset();
+  panelView._submitBtn.disabled = true;
 };
 
 const init = function () {
@@ -183,6 +196,7 @@ const init = function () {
   panelView.addHandlerRemoveImage(controlRemoveImage);
   panelView.addHandlerSubmit(controlSubmit);
   panelView.addHandlerRouteCardClick(controlRouteCardClick);
+  panelView.addHandlerRoutePanelBack(controlRouteBackClick);
   panelView.addHandlerClear(controlClear);
 };
 init();

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -48,6 +48,10 @@ const controlPreviewClick = function (i) {
   });
 };
 
+const controlRouteCardClick = function () {
+  panelView.renderRoutePanel(model.state.routeData);
+};
+
 const controlRemoveImage = function (i) {
   mapView.photoMarkers.eachLayer((layer) => {
     if (layer.photoIndex === +i) {
@@ -178,6 +182,7 @@ const init = function () {
   panelView.addHandlerRemoveCurrentLocation(controlRemoveLocationPreview);
   panelView.addHandlerRemoveImage(controlRemoveImage);
   panelView.addHandlerSubmit(controlSubmit);
+  panelView.addHandlerRouteCardClick(controlRouteCardClick);
   panelView.addHandlerClear(controlClear);
 };
 init();

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -65,8 +65,8 @@ const controlRouteCardClick = function () {
   panelView.renderRoutePanel(model.state.routeData, model.state.transportMode);
 };
 const controlRouteBackClick = function () {
-  console.log('clicked')
-  // panelView.renderForm();
+  panelView.routePanel.remove();
+  panelView.renderAllImgs(state);
 }
 
 const controlRemoveImage = function (i) {

--- a/src/js/model.js
+++ b/src/js/model.js
@@ -3,6 +3,7 @@ export const state = {
   imageCoords: [],
   uploadedImages: [],
   currentLatLng: [],
+  transportMode: '',
   routeData: {},
 };
 

--- a/src/js/views/panelView.js
+++ b/src/js/views/panelView.js
@@ -8,6 +8,7 @@ class PanelView {
   preview = document.querySelector('#preview');
   form = document.querySelector('form');
   routePreviewCard;
+  routePanel;
   locationPreviewCard;
 
   addHandlerFileInput(handler) {
@@ -19,13 +20,17 @@ class PanelView {
     });
   }
   addHandlerRemoveImage(handler) {
-    this.preview.addEventListener('click', function (e) {
-      const removeBtn = e.target.closest('.preview__card--remove-btn');
-      if (!removeBtn) return;
-      e.stopImmediatePropagation();
-      const imgIndex = e.target.closest('.preview__card').dataset.photoIndex;
-      handler(imgIndex);
-    }, true);
+    this.preview.addEventListener(
+      'click',
+      function (e) {
+        const removeBtn = e.target.closest('.preview__card--remove-btn');
+        if (!removeBtn) return;
+        e.stopImmediatePropagation();
+        const imgIndex = e.target.closest('.preview__card').dataset.photoIndex;
+        handler(imgIndex);
+      },
+      true
+    );
   }
   addHandlerPreviewClick(handler) {
     this.preview.addEventListener('click', function (e) {
@@ -35,23 +40,22 @@ class PanelView {
       handler(imgIndex);
     });
   }
-  addHandlerRouteCardClick(handler){
-    document.addEventListener('click', function(e){
-      const routePreviewCard = e.target.closest('.preview__card--route')
-      if(!routePreviewCard) return;
-      console.log(routePreviewCard);
-      handler()
-    })
+  addHandlerRouteCardClick(handler) {
+    document.addEventListener('click', function (e) {
+      const routePreviewCard = e.target.closest('.preview__card--route');
+      if (!routePreviewCard) return;
+      handler();
+    });
   }
-  addHandlerLocationPreviewClick(handler){
-    this.preview.addEventListener('click', function(e) {
+  addHandlerLocationPreviewClick(handler) {
+    this.preview.addEventListener('click', function (e) {
       e.preventDefault();
       const locationPreviewCard = e.target.closest('.location__card');
-      if(!locationPreviewCard) return;
+      if (!locationPreviewCard) return;
       handler();
-    })
+    });
   }
-  addHandlerRemoveCurrentLocation(handler){
+  addHandlerRemoveCurrentLocation(handler) {
     this.preview.addEventListener('click', function (e) {
       const removeBtn = e.target.closest('.location__card--remove-btn');
       if (!removeBtn) return;
@@ -72,17 +76,17 @@ class PanelView {
   addHandlerClear(handler) {
     this._clearBtn.addEventListener('click', (e) => {
       handler();
-      // Remove all image previews
-      this.preview.replaceChildren();
-      this.routePreviewCard.remove();
-
-      // reset to default coords/world view
-      this.form.reset();
-      this._submitBtn.disabled = true;
     });
   }
   addHandlerUserLocation(handler) {
     this._userLocationInput.addEventListener('change', (e) => handler(e));
+  }
+  addHandlerRoutePanelBack(handler) {
+    document.addEventListener('click', function (e) {
+      const routePanelBackBtn = e.target.closest('.route-panel--back-btn');
+      if (!routePanelBackBtn) return;
+      handler();
+    });
   }
   // Function to print image, info and coords to preview area
   renderPreviewCard(file, exifData, i) {
@@ -154,34 +158,49 @@ class PanelView {
     </span>
     `;
   }
-  renderRoutePanel(routeData) {
-    console.log(routeData)
+  renderRoutePanel(routeData, transportMode) {
     const routeTime = miliToTime(routeData.paths[0].time);
     const routeDistance = routeData.paths[0].distance;
-    const routePreviewEl = document.getElementsByClassName(
-      'route-panel'
-    );
-    const routePanel = document.createElement('div');
+    const routePreviewEl = document.getElementsByClassName('route-panel');
     if (!routePreviewEl.length) {
-      routePanel.classList.add(
-        'route-panel',
-      );
-      // this._parentElement.replaceChildren(routePanel);
-      this.preview.classList.add('hidden')
-      this.preview.insertAdjacentElement('beforebegin', routePanel);
+      this.routePanel = document.createElement('div');
+      this.routePanel.classList.add('route-panel', 'preview__card--text');
     }
-    routePanel.innerHTML = `
-    <a href="#">Back</a>
-    <h4>Route</h4>
-    <span><h4>${routeTime}</h4></span>
-    <p>${round(toMiles(routeDistance), 100)} mi</p>
-    ${routeData.paths[0].instructions.map((step, index) => {
-      console.log(step)
-      return (`<p>Step ${index + 1}</p>
-      <p>${step.text}</p>
-      `)
-    })}
+
+    const startPoint = routeData.paths[0].points.coordinates[0].map((e) =>
+      e.toFixed(2)
+    );
+    const endPoint = routeData.paths[0].points.coordinates
+      .pop()
+      .map((e) => e.toFixed(2));
+    this.routePanel.innerHTML = `
+    <h3>Selected Route</h3>
+    <h4>Traveling by ${transportMode} from ${startPoint} to ${endPoint}</h4>
+    <dl>
+      <dt>${routeTime}</dt>
+      <dd>${round(toMiles(routeDistance), 100)} miles</dd>
+    </dl>
     `;
+
+    const routePanelInstructions = document.createElement('dl');
+    routePanelInstructions.innerHTML = `${routeData.paths[0].instructions
+      .map((step, index) => {
+        return `
+        <dt>${index + 1}</dt>
+        <dd>${step.text}</dd>
+      `;
+      })
+      .join('')}`;
+    this.routePanel.appendChild(routePanelInstructions);
+
+    // Create back button
+    const routePanelBackBtn = document.createElement('button');
+    routePanelBackBtn.innerText = '←';
+    routePanelBackBtn.setAttribute('title', 'Back');
+    routePanelBackBtn.classList.add('route-panel--back-btn');
+    this.routePanel.insertAdjacentElement('afterbegin', routePanelBackBtn);
+
+    this._parentElement.replaceChildren(this.routePanel);
   }
   renderLocationCard(location) {
     if (!location) return;

--- a/src/js/views/panelView.js
+++ b/src/js/views/panelView.js
@@ -35,6 +35,14 @@ class PanelView {
       handler(imgIndex);
     });
   }
+  addHandlerRouteCardClick(handler){
+    document.addEventListener('click', function(e){
+      const routePreviewCard = e.target.closest('.preview__card--route')
+      if(!routePreviewCard) return;
+      console.log(routePreviewCard);
+      handler()
+    })
+  }
   addHandlerLocationPreviewClick(handler){
     this.preview.addEventListener('click', function(e) {
       e.preventDefault();
@@ -104,7 +112,7 @@ class PanelView {
     const dateObject = new Date(year, month - 1, day, hours, minutes, seconds);
 
     previewCardText.innerHTML = `
-      <h4>${file.name}</h4>
+
       <dl>
         <dt>Date:</dt><dd>${dateObject.toLocaleDateString()}</dd>
         <dt>Time:</dt><dd>${dateObject.toLocaleTimeString([], {
@@ -144,6 +152,35 @@ class PanelView {
     <span><h4>${routeTime}</h4>
     <p>${round(toMiles(routeDistance), 100)} mi</p>
     </span>
+    `;
+  }
+  renderRoutePanel(routeData) {
+    console.log(routeData)
+    const routeTime = miliToTime(routeData.paths[0].time);
+    const routeDistance = routeData.paths[0].distance;
+    const routePreviewEl = document.getElementsByClassName(
+      'route-panel'
+    );
+    const routePanel = document.createElement('div');
+    if (!routePreviewEl.length) {
+      routePanel.classList.add(
+        'route-panel',
+      );
+      // this._parentElement.replaceChildren(routePanel);
+      this.preview.classList.add('hidden')
+      this.preview.insertAdjacentElement('beforebegin', routePanel);
+    }
+    routePanel.innerHTML = `
+    <a href="#">Back</a>
+    <h4>Route</h4>
+    <span><h4>${routeTime}</h4></span>
+    <p>${round(toMiles(routeDistance), 100)} mi</p>
+    ${routeData.paths[0].instructions.map((step, index) => {
+      console.log(step)
+      return (`<p>Step ${index + 1}</p>
+      <p>${step.text}</p>
+      `)
+    })}
     `;
   }
   renderLocationCard(location) {

--- a/src/js/views/panelView.js
+++ b/src/js/views/panelView.js
@@ -205,7 +205,7 @@ class PanelView {
     routePanelBackBtn.classList.add('route-panel--back-btn');
     this.routePanel.insertAdjacentElement('afterbegin', routePanelBackBtn);
 
-    this._parentElement.replaceChildren(this.routePanel);
+    this.preview.replaceChildren(this.routePanel);
   }
   renderLocationCard(location) {
     if (!location) return;

--- a/src/styles.css
+++ b/src/styles.css
@@ -332,6 +332,10 @@ button:disabled:hover {
   font-size: 0.875rem;
   display: inline;
 }
+.route-panel {
+  background: #fff;;
+  border: 2px solid var(--lake);
+}
 .carto {
   background: #faf4e5;
   padding: 1rem;

--- a/src/styles.css
+++ b/src/styles.css
@@ -200,10 +200,11 @@ button:disabled:hover {
   max-width: 100%;
   max-height: 9rem;
   background: white;
-  align-items: flex-start;
+  align-items: stretch;
   overflow: hidden;
   display: grid;
   grid-template-columns: 8rem 1fr;
+  grid-template-rows: minmax(5px, 7.75rem);
   transition: all 0.24s;
   position: relative;
   border: 2px solid var(--field);
@@ -250,12 +251,14 @@ button:disabled:hover {
   border: none;
 }
 .preview__card--header {
-  overflow: hidden;
   padding: 0.5rem;
+  display: flex;
+  overflow: hidden;
+  justify-content: center;
 }
 .preview__card--text {
-  font-size: 0.75rem;
-  padding: 0.75rem;
+  font-size: 0.875rem;
+  padding: 0.75rem 0.5rem;
   overflow: hidden;
 }
 .preview__card--text h4 {
@@ -281,13 +284,13 @@ button:disabled:hover {
   align-items: baseline;
   padding: 0;
   margin: 0;
-  gap: 0.25rem;
+  gap: 0.5rem 0.25rem;
 }
 .preview__card--text dt {
   padding: 0;
   margin: 0;
   text-transform: uppercase;
-  font-size: 12px;
+  font-size: 0.75rem;
   letter-spacing: 0.25px;
   color: #808080;
 }
@@ -296,9 +299,14 @@ button:disabled:hover {
   margin: 0;
 }
 .preview__image {
-  max-width: 100%;
-  max-height: 5rem;
   border: 2px solid var(--field);
+  max-width: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+  max-height: 100%;
+  overflow: hidden;
+  flex: 1;
 }
 .preview__image::after {
   box-shadow: inset 3px 3px 10px 0 #000000;

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,10 +4,11 @@
 }
 body {
   font-family: 'Montserrat', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  /* color: var(--lake); */
+  color: var(--lake);
   margin: 0;
   padding: 0;
   background: #F7F6F2;
+  background: #FAF4E5;
   height: 100vh;
   max-width: 100vw;
 }
@@ -56,7 +57,10 @@ button {
   text-align: center;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: #fff;
+  font-weight: 600;
+  color: var(--lake);
+  background: #fff;
+
   padding: 0.75rem 1rem;
   border: 0;
   transition: 248ms;
@@ -68,11 +72,11 @@ button {
   cursor: pointer;
   transition: transform 0.24s;
   border: 2px solid transparent;
+  border-color: var(--lake);
 }
 
 button:hover {
   transform: translateY(-2px);
-  border: 2px solid white;
 }
 button:disabled {
   background: #a5a5a5;
@@ -101,17 +105,19 @@ button:disabled:hover {
   align-items: center;
   position: sticky;
   bottom: 0;
-  border: 2px solid white;
-  font-size: 1rem;
   padding: 1rem;
   flex: 1;
+  background: var(--lake);
+  color: #fff;
+  border-color: transparent
+}
+#submit-route-btn:disabled {
+  background: #a5a5a5;
 }
 #clear-btn {
   flex: 1;
   margin-top: auto;
   padding: 1rem;
-  color: initial;
-  background: white;
 }
 .preview__card {
   max-width: 100%;
@@ -260,4 +266,7 @@ button:disabled:hover {
 .marker-photo {
   max-width: 100%;
   min-width: 8rem;
+}
+.hidden {
+  display: none;
 }


### PR DESCRIPTION
Renders a route preview panel. Clicking route preview card swaps preview image view with full route instructions. Contributes to #9 

https://github.com/LanesGood/snappy-trails/assets/12634024/02d89d08-7a04-430d-90e8-7f7d4e49207b

To do in later branch:
- animate transition
- replace full form with route, then re-render form and preview on back click
- Adjust time and distance display
- Improve instruction display
- Consider truncating instructions